### PR TITLE
Added a change event trigger for better select2 compatibility

### DIFF
--- a/assets/javascripts/freight_train/jquery_adapter.js
+++ b/assets/javascripts/freight_train/jquery_adapter.js
@@ -135,9 +135,9 @@ FT.Adapters.jQuery = {
     } else if($controls.is(':checkbox')) {
       $controls.attr('checked', (value == 'true') ? 'checked' : null);
     } else if($controls.prop('multiple')) {
-      $controls.val(value.split(','));
+      $controls.val(value.split(',')).trigger('change');
     } else {
-      $controls.val(value);
+      $controls.val(value).trigger('change');
     }
   },
   


### PR DESCRIPTION
Loading in values to a multi-select calls `.trigger('change')` to alert select2 (or whatever else might be listening) to the new values.