### PR TITLE
Improved resetOnCreate dealing with select2 multi-selects

### DIFF
--- a/assets/javascripts/freight_train/core.js
+++ b/assets/javascripts/freight_train/core.js
@@ -718,7 +718,10 @@
     }
     for(var i=0, ii=selects.length; i<ii; i++) {
       var select = selects[i];
-      fieldToBeReset(select.id) && (select.selectedIndex = 0);
+      if(fieldToBeReset(select.id)) {
+        select.selectedIndex = select.multiple ? -1 : 0;
+        _$.fire(select,'change');
+      }
     }
     for(var i=0, ii=nested_editors.length; i<ii; i++) {
       resetNestedEditor(nested_editors[i]);


### PR DESCRIPTION
When working with a multiselect, calling `resetOnCreate` now selects _nothing_ instead of the first option as with normal select boxes. Also fires a `change` event to better work with `select2`